### PR TITLE
Fix packet size calculation

### DIFF
--- a/liffylights.py
+++ b/liffylights.py
@@ -161,7 +161,7 @@ class LiffyLights():
             contents.extend(payload)
 
         # get packet size
-        size = pack("<H", len(contents) << 1)
+        size = pack("<H", len(contents) + 2)
 
         # assemble complete packet
         packet = bytearray(size)


### PR DESCRIPTION
The correct size is the length of the contents plus 2 for the size itself.
LIFX Generation 2 firmware version 1.22 has started checking this.